### PR TITLE
[#16] Change storage to persist logged user between tabs

### DIFF
--- a/frontend/src/app/token-storage.service.ts
+++ b/frontend/src/app/token-storage.service.ts
@@ -7,27 +7,29 @@ import { LoggedUser, LoggedUserDto } from './dto/user.dto';
 export class TokenStorageService {
   private authTokenKey = 'auth-token';
   private authUserKey = 'auth-user';
+  private storage = window.localStorage;
+
   constructor() { }
 
   signOut(): void {
-    window.sessionStorage.removeItem(this.authTokenKey);
-    window.sessionStorage.removeItem(this.authUserKey);
+    this.storage.removeItem(this.authTokenKey);
+    this.storage.removeItem(this.authUserKey);
   }
 
   saveToken(token: string): void {
-    window.sessionStorage.setItem(this.authTokenKey, token);
+    this.storage.setItem(this.authTokenKey, token);
   }
 
   getToken(): string | null {
-    return window.sessionStorage.getItem(this.authTokenKey);
+    return this.storage.getItem(this.authTokenKey);
   }
 
   saveUser(user: LoggedUser): void {
-    window.sessionStorage.setItem(this.authUserKey, JSON.stringify(user));
+    this.storage.setItem(this.authUserKey, JSON.stringify(user));
   }
 
   getUser(): LoggedUser | null {
-    const user = window.sessionStorage.getItem(this.authUserKey);
+    const user = this.storage.getItem(this.authUserKey);
     if (user) {
       return new LoggedUser(JSON.parse(user) as LoggedUserDto);
     }


### PR DESCRIPTION
This PR changes `sessionStorage` to `localStorage` to make logged user persistent between tabs in a browers.

Closes #16 

> Estimated: 1 SP
> Completed: 1 SP